### PR TITLE
Add more post-reqs for the tree diagram

### DIFF
--- a/apps/frontend/src/components/PostReqCourses.tsx
+++ b/apps/frontend/src/components/PostReqCourses.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Link from "next/link"; // Import Next.js Link component
 import { useFetchCourseInfo } from "~/app/api/course";
 
 interface TreeNode {
@@ -30,17 +31,17 @@ export const PostReqCourses = ({ courseID }: Props) => {
               marginBottom: "10px",
             }}
           >
+            {/* Line connector */}
+            <div
+              style={{
+                width: "20px",
+                height: "1px",
+                backgroundColor: "#d1d5db",
+                marginRight: "10px",
+              }}
+            ></div>
 
-        {/* Red arrow */}
-        <div
-                style={{
-                  width: "20px",
-                  height: "1px",
-                  backgroundColor: "#d1d5db",
-                  marginRight: "5px",
-                }}
-              ></div>
-
+            {/* Course ID button */}
             <button
               onClick={() => window.location.href = `/course/${node.courseID}`}
               style={{
@@ -53,12 +54,15 @@ export const PostReqCourses = ({ courseID }: Props) => {
                 border: "1px solid #d1d5db",
                 borderRadius: "4px",
                 boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.05)",
-                textDecoration: "none",
                 cursor: "pointer",
+                textDecoration: "none",
+                minWidth: "100px", // Ensure consistent width
+                display: "inline-block",
               }}
             >
               {node.courseID}
             </button>
+
             {/* Render child nodes recursively */}
             {node.postreqs && renderTree(node.postreqs)}
           </div>
@@ -77,10 +81,18 @@ export const PostReqCourses = ({ courseID }: Props) => {
       {childNodes.length > 0 ? (
         renderTree(childNodes)
       ) : (
-        <div style={{ fontStyle: "italic", color: "#000000", textAlign: "center", fontSize: "14px", marginTop: "-10px", fontWeight: "bold" }}>
-            No further post-requisites
+        <div
+          style={{
+            fontStyle: "italic",
+            color: "#000000",
+            textAlign: "center",
+            fontSize: "14px",
+            marginTop: "-10px",
+            fontWeight: "bold",
+          }}
+        >
+          No further post-requisites
         </div>
-
       )}
     </div>
   );

--- a/apps/frontend/src/components/PostReqCourses.tsx
+++ b/apps/frontend/src/components/PostReqCourses.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { useFetchCourseInfo } from "~/app/api/course";
+
+interface TreeNode {
+  courseID: string;
+  postreqs?: TreeNode[];
+}
+
+interface Props {
+  courseID: string;
+}
+
+export const PostReqCourses = ({ courseID }: Props) => {
+  const { isPending: isCourseInfoPending, data: info } = useFetchCourseInfo(courseID);
+
+  if (isCourseInfoPending || !info) {
+    return null;
+  }
+
+  // Recursive function to render only the child branches
+  const renderTree = (nodes: TreeNode[]) => {
+    return (
+      <div style={{ display: "flex", flexDirection: "column", marginLeft: "20px" }}>
+        {nodes.map((node) => (
+          <div
+            key={node.courseID}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              marginBottom: "10px",
+            }}
+          >
+
+        {/* Red arrow */}
+        <div
+                style={{
+                  width: "20px",
+                  height: "1px",
+                  backgroundColor: "#d1d5db",
+                  marginRight: "5px",
+                }}
+              ></div>
+
+            <button
+              onClick={() => window.location.href = `/course/${node.courseID}`}
+              style={{
+                fontWeight: "normal",
+                textAlign: "center",
+                padding: "5px 10px",
+                fontSize: "14px",
+                backgroundColor: "#f9fafb",
+                color: "#111827",
+                border: "1px solid #d1d5db",
+                borderRadius: "4px",
+                boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.05)",
+                textDecoration: "none",
+                cursor: "pointer",
+              }}
+            >
+              {node.courseID}
+            </button>
+            {/* Render child nodes recursively */}
+            {node.postreqs && renderTree(node.postreqs)}
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  // Transform fetched data into a tree structure excluding the parent node
+  const childNodes: TreeNode[] = info.postreqs?.map((postreq: string) => ({
+    courseID: postreq,
+  })) || [];
+
+  return (
+    <div>
+      {childNodes.length > 0 ? (
+        renderTree(childNodes)
+      ) : (
+        <div style={{ fontStyle: "italic", color: "#000000", textAlign: "center", fontSize: "14px", marginTop: "-10px", fontWeight: "bold" }}>
+            No further post-requisites
+        </div>
+
+      )}
+    </div>
+  );
+};
+
+export default PostReqCourses;

--- a/apps/frontend/src/components/ReqTreeCard.tsx
+++ b/apps/frontend/src/components/ReqTreeCard.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Card } from "./Card";
 import ReqTreeDetail from "./ReqTreeDetail";
+import postreqCourses from "./PostReqCourses";
 
 interface TreeNode {
   courseID: string;
@@ -39,6 +40,7 @@ const ReqTreeCard: React.FC<ReqTreeCardProps> = ({ courseID, prereqs, postreqs }
       ) : (
         <ReqTreeDetail root={tree} />
       )}
+
     </Card>
   );
 };

--- a/apps/frontend/src/components/ReqTreeCard.tsx
+++ b/apps/frontend/src/components/ReqTreeCard.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Card } from "./Card";
 import ReqTreeDetail from "./ReqTreeDetail";
-import postreqCourses from "./PostReqCourses";
 
 interface TreeNode {
   courseID: string;

--- a/apps/frontend/src/components/ReqTreeDetail.tsx
+++ b/apps/frontend/src/components/ReqTreeDetail.tsx
@@ -91,6 +91,14 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
                 justifyContent: "space-between", // Space between course ID and button
               }}
             >
+              <div
+                style={{
+                  width: "20px",
+                  height: "1px",
+                  backgroundColor: "#d1d5db",
+                  marginRight: "5px",
+                }}
+              ></div>
               <Link href={`/course/${postreq.courseID}`} passHref>
                 <div
                   style={{

--- a/apps/frontend/src/components/ReqTreeDetail.tsx
+++ b/apps/frontend/src/components/ReqTreeDetail.tsx
@@ -1,5 +1,6 @@
-import React from "react";
-import Link from "next/link"; // Import Next.js Link component
+import React, { useState } from "react";
+import Link from "next/link";
+import PostReqCourses from "./PostReqCourses"; // Import PostReqCourses component
 
 interface TreeNode {
   courseID: string;
@@ -12,9 +13,15 @@ interface ReqTreeProps {
 }
 
 const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
+  const [expandedCourseID, setExpandedCourseID] = useState<string | null>(null);
+
+  const togglePostReqs = (courseID: string) => {
+    // Toggle expanded state for the course
+    setExpandedCourseID((prev) => (prev === courseID ? null : courseID));
+  };
+
   return (
     <div style={{ display: "flex", alignItems: "center", justifyContent: "center" }}>
-      
       {/* Prerequisites on the Left */}
       {root.prereqs && root.prereqs.length > 0 && (
         <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", marginRight: "20px" }}>
@@ -27,7 +34,7 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
                     textAlign: "center",
                     padding: "5px 10px",
                     fontSize: "14px",
-                    backgroundColor: "#f9fafb", 
+                    backgroundColor: "#f9fafb",
                     color: "#111827",
                     border: "1px solid #d1d5db",
                     borderRadius: "4px",
@@ -89,17 +96,40 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
                     textAlign: "center",
                     padding: "5px 10px",
                     fontSize: "14px",
-                    backgroundColor: "#f9fafb", 
+                    backgroundColor: "#f9fafb",
                     color: "#111827",
                     border: "1px solid #d1d5db",
                     borderRadius: "4px",
                     boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.05)",
                     cursor: "pointer",
+                    flex: "1",
                   }}
                 >
                   {postreq.courseID}
                 </div>
               </Link>
+              <button
+                style={{
+                  marginLeft: "5px",
+                  padding: "2px 6px",
+                  backgroundColor: "#007BFF",
+                  color: "#FFFFFF",
+                  border: "none",
+                  borderRadius: "3px",
+                  cursor: "pointer",
+                  fontSize: "10px",
+                  marginRight: "10px"
+                }}
+                onClick={() => togglePostReqs(postreq.courseID)}
+              >
+                {expandedCourseID === postreq.courseID ? "Hide" : "View More"}
+              </button>
+              {/* Render PostReqCourses dynamically */}
+              {expandedCourseID === postreq.courseID && (
+                <div style={{ marginTop: "10px", marginLeft: "0px" }}>
+                  <PostReqCourses courseID={postreq.courseID} />
+                </div>
+              )}
             </div>
           ))}
         </div>

--- a/apps/frontend/src/components/ReqTreeDetail.tsx
+++ b/apps/frontend/src/components/ReqTreeDetail.tsx
@@ -40,6 +40,7 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
                     borderRadius: "4px",
                     boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.05)",
                     cursor: "pointer",
+                    minWidth: "80px", // Consistent width
                   }}
                 >
                   {prereq.courseID}
@@ -71,6 +72,7 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
           borderRadius: "4px",
           boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.1)",
           margin: "0 20px",
+          minWidth: "80px", // Consistent width
         }}
       >
         {root.courseID}
@@ -80,15 +82,15 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
       {root.postreqs && root.postreqs.length > 0 && (
         <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-start", marginLeft: "20px" }}>
           {root.postreqs.map((postreq) => (
-            <div key={postreq.courseID} style={{ display: "flex", alignItems: "center", marginBottom: "10px" }}>
-              <div
-                style={{
-                  width: "20px",
-                  height: "1px",
-                  backgroundColor: "#d1d5db",
-                  marginRight: "5px",
-                }}
-              ></div>
+            <div
+              key={postreq.courseID}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                marginBottom: "10px",
+                justifyContent: "space-between", // Space between course ID and button
+              }}
+            >
               <Link href={`/course/${postreq.courseID}`} passHref>
                 <div
                   style={{
@@ -102,23 +104,24 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
                     borderRadius: "4px",
                     boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.05)",
                     cursor: "pointer",
-                    flex: "1",
+                    minWidth: "80px", // Consistent width
+                    marginRight: "10px", // Space between course ID and button
                   }}
                 >
                   {postreq.courseID}
                 </div>
               </Link>
               <button
+                aria-label={`Toggle post-requisites for ${postreq.courseID}`}
                 style={{
                   marginLeft: "5px",
-                  padding: "2px 6px",
-                  backgroundColor: "#007BFF",
+                  padding: "5px 10px",
+                  backgroundColor: "#007BFF", // Button color
                   color: "#FFFFFF",
                   border: "none",
-                  borderRadius: "3px",
+                  borderRadius: "4px",
                   cursor: "pointer",
-                  fontSize: "10px",
-                  marginRight: "10px"
+                  fontSize: "12px",
                 }}
                 onClick={() => togglePostReqs(postreq.courseID)}
               >
@@ -126,7 +129,7 @@ const ReqTreeDetail: React.FC<ReqTreeProps> = ({ root }) => {
               </button>
               {/* Render PostReqCourses dynamically */}
               {expandedCourseID === postreq.courseID && (
-                <div style={{ marginTop: "10px", marginLeft: "0px" }}>
+                <div style={{ marginTop: "10px", marginLeft: "20px" }}>
                   <PostReqCourses courseID={postreq.courseID} />
                 </div>
               )}


### PR DESCRIPTION
This PR is to add post-requisites to the post-requisites that already show on the Requisite Tree. Now users can see a button next to the post reqs that can expand to show more post-reqs:

<img width="700" alt="Screenshot 2024-12-10 at 2 06 26 AM" src="https://github.com/user-attachments/assets/7063f26e-e17b-4905-add8-b09f773ace17">


**Changes Made**
- PostReqCourses.tsx: I added this file to make it easier and clearer when needing to show more post-reqs. This function is called in ReqTreeDetails.tsx. This file renders the boxes for the extra post-reqs. 
- I modified ReqTreeDetails.tsx to make it compatible and call the PstReqCourses function. The buttons were also added to this file. 
- Small edits were made to the ReqTreeCard for visual reasons. 
- The user is only able to click 'View More' on one course. If one post-req course is already expanded and the user selects 'View More' on another course, that initial course will compress. This was done so that the post reqs will not take a lot of space on the screen and overwhelm users. 

*courses with a lot of post reqs can take a little more time to load